### PR TITLE
Add dry-run flag

### DIFF
--- a/src/cli/base.ts
+++ b/src/cli/base.ts
@@ -25,7 +25,6 @@ export default abstract class BaseCommand extends Command {
 
   static flags = {
     help: flags.help({ char: 'h', description: 'Show help' }),
-
     body: flags.string({
       description: 'Body of comment to post, mutually exclusive with body-file',
       exclusive: ['body-file'],
@@ -38,6 +37,10 @@ export default abstract class BaseCommand extends Command {
     tag: flags.string({
       description:
         'Will match any comments with same tag when upserting, hiding or deleting',
+    }),
+    'dry-run': flags.boolean({
+      description: 'Skips any comment posting, deleting or hiding',
+      default: false,
     }),
   };
 
@@ -121,6 +124,7 @@ export default abstract class BaseCommand extends Command {
   ): CommentHandlerOptions {
     return {
       tag: flags.tag,
+      dryRun: flags['dry-run'],
       logger: this.logger,
       errorHandler: this.errorHandler,
     };

--- a/src/platforms/autodetect.ts
+++ b/src/platforms/autodetect.ts
@@ -64,7 +64,6 @@ export function autodetect(opts?: AutoDetectOptions): Platform | null | never {
         (detectResult as AzureDevOpsDetectResult).token,
         opts
       );
-      break;
     default:
       errorHandler(`Unsupported platform: ${platform}`);
       return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface Platform {
 
 export type CommentHandlerOptions = PlatformOptions & {
   tag?: string;
+  dryRun: boolean;
 };
 
 export interface CommentHandler {


### PR DESCRIPTION
The `--dry-run` flag doesn't post,hide or delete comments, but is useful for testing to make sure we detect the environment correctly and retrieve the latest comments.